### PR TITLE
feat: support arrays and array indexes/slices

### DIFF
--- a/apps/parser/generated/cst-types.ts
+++ b/apps/parser/generated/cst-types.ts
@@ -90,10 +90,19 @@ export interface ChainValueCstNode extends CstNode {
 
 export type ChainValueCstChildren = {
   value: ValueCstNode[];
-  LBRACK?: IToken[];
+  indexOrSlice?: IndexOrSliceCstNode[];
+};
+
+export interface IndexOrSliceCstNode extends CstNode {
+  name: 'indexOrSlice';
+  children: IndexOrSliceCstChildren;
+}
+
+export type IndexOrSliceCstChildren = {
+  LBRACK: IToken[];
   expression?: ExpressionCstNode[];
   COLON?: IToken[];
-  RBRACK?: IToken[];
+  RBRACK: IToken[];
 };
 
 export interface ValueCstNode extends CstNode {
@@ -146,6 +155,7 @@ export interface ICstNodeVisitor<IN, OUT> extends ICstVisitor<IN, OUT> {
   declaration(children: DeclarationCstChildren, param?: IN): OUT;
   expression(children: ExpressionCstChildren, param?: IN): OUT;
   chainValue(children: ChainValueCstChildren, param?: IN): OUT;
+  indexOrSlice(children: IndexOrSliceCstChildren, param?: IN): OUT;
   value(children: ValueCstChildren, param?: IN): OUT;
   constant(children: ConstantCstChildren, param?: IN): OUT;
   type(children: TypeCstChildren, param?: IN): OUT;

--- a/apps/parser/generated/cst-types.ts
+++ b/apps/parser/generated/cst-types.ts
@@ -76,11 +76,24 @@ export interface ExpressionCstNode extends CstNode {
 }
 
 export type ExpressionCstChildren = {
-  value: ValueCstNode[];
+  chainValue: ChainValueCstNode[];
   PostFix?: IToken[];
   CmpAsgn?: IToken[];
   BinOp?: IToken[];
   expression?: ExpressionCstNode[];
+};
+
+export interface ChainValueCstNode extends CstNode {
+  name: 'chainValue';
+  children: ChainValueCstChildren;
+}
+
+export type ChainValueCstChildren = {
+  value: ValueCstNode[];
+  LBRACK?: IToken[];
+  expression?: ExpressionCstNode[];
+  COLON?: IToken[];
+  RBRACK?: IToken[];
 };
 
 export interface ValueCstNode extends CstNode {
@@ -90,7 +103,7 @@ export interface ValueCstNode extends CstNode {
 
 export type ValueCstChildren = {
   UnOp?: IToken[];
-  value?: ValueCstNode[];
+  chainValue?: ChainValueCstNode[];
   constant?: ConstantCstNode[];
   ID?: IToken[];
   LPAREN?: IToken[];
@@ -107,9 +120,13 @@ export type ConstantCstChildren = {
   STRING?: IToken[];
   BOOL?: IToken[];
   BIN?: IToken[];
-  INT?: IToken[];
   CMPX?: IToken[];
   REAL?: IToken[];
+  INT?: IToken[];
+  LBRACK?: IToken[];
+  expression?: ExpressionCstNode[];
+  SEP?: IToken[];
+  RBRACK?: IToken[];
 };
 
 export interface TypeCstNode extends CstNode {
@@ -128,6 +145,7 @@ export interface ICstNodeVisitor<IN, OUT> extends ICstVisitor<IN, OUT> {
   body(children: BodyCstChildren, param?: IN): OUT;
   declaration(children: DeclarationCstChildren, param?: IN): OUT;
   expression(children: ExpressionCstChildren, param?: IN): OUT;
+  chainValue(children: ChainValueCstChildren, param?: IN): OUT;
   value(children: ValueCstChildren, param?: IN): OUT;
   constant(children: ConstantCstChildren, param?: IN): OUT;
   type(children: TypeCstChildren, param?: IN): OUT;

--- a/apps/parser/generated/cst-types.ts
+++ b/apps/parser/generated/cst-types.ts
@@ -134,7 +134,7 @@ export type ConstantCstChildren = {
   INT?: IToken[];
   LBRACK?: IToken[];
   expression?: ExpressionCstNode[];
-  SEP?: IToken[];
+  COMMA?: IToken[];
   RBRACK?: IToken[];
 };
 

--- a/apps/parser/generated/cst-types.ts
+++ b/apps/parser/generated/cst-types.ts
@@ -145,6 +145,18 @@ export interface TypeCstNode extends CstNode {
 
 export type TypeCstChildren = {
   BASIC_TYPE: IToken[];
+  arrayType?: ArrayTypeCstNode[];
+};
+
+export interface ArrayTypeCstNode extends CstNode {
+  name: 'arrayType';
+  children: ArrayTypeCstChildren;
+}
+
+export type ArrayTypeCstChildren = {
+  LBRACK: IToken[];
+  INT?: IToken[];
+  RBRACK: IToken[];
 };
 
 export interface ICstNodeVisitor<IN, OUT> extends ICstVisitor<IN, OUT> {
@@ -159,4 +171,5 @@ export interface ICstNodeVisitor<IN, OUT> extends ICstVisitor<IN, OUT> {
   value(children: ValueCstChildren, param?: IN): OUT;
   constant(children: ConstantCstChildren, param?: IN): OUT;
   type(children: TypeCstChildren, param?: IN): OUT;
+  arrayType(children: ArrayTypeCstChildren, param?: IN): OUT;
 }

--- a/apps/parser/generated/syntax-diagrams.html
+++ b/apps/parser/generated/syntax-diagrams.html
@@ -816,6 +816,51 @@
         "label": "BASIC_TYPE",
         "idx": 0,
         "pattern": "bool|(i|u|b)(8|16|32|64)|(r|x)(32|64)|string"
+      },
+      {
+        "type": "Repetition",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "NonTerminal",
+            "name": "arrayType",
+            "idx": 0
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "arrayType",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Terminal",
+        "name": "LBRACK",
+        "label": "LBRACK",
+        "idx": 0,
+        "pattern": "["
+      },
+      {
+        "type": "Option",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Terminal",
+            "name": "INT",
+            "label": "INT",
+            "idx": 0,
+            "pattern": "(\\+|-)?(0|[1-9]([\\d_]+\\d|\\d)?)"
+          }
+        ]
+      },
+      {
+        "type": "Terminal",
+        "name": "RBRACK",
+        "label": "RBRACK",
+        "idx": 0,
+        "pattern": "]"
       }
     ]
   }

--- a/apps/parser/generated/syntax-diagrams.html
+++ b/apps/parser/generated/syntax-diagrams.html
@@ -1,694 +1,815 @@
+
 <!-- This is a generated file -->
 <!DOCTYPE html>
 <meta charset="utf-8">
 <style>
   body {
-    background-color: hsl(30, 20%, 95%);
+    background-color: hsl(30, 20%, 95%)
   }
 </style>
 
-<link rel="stylesheet" href="https://unpkg.com/chevrotain@11.0.3/diagrams/diagrams.css">
 
-<script src="https://unpkg.com/chevrotain@11.0.3/diagrams/vendor/railroad-diagrams.js"></script>
-<script src="https://unpkg.com/chevrotain@11.0.3/diagrams/src/diagrams_builder.js"></script>
-<script src="https://unpkg.com/chevrotain@11.0.3/diagrams/src/diagrams_behavior.js"></script>
-<script src="https://unpkg.com/chevrotain@11.0.3/diagrams/src/main.js"></script>
+<link rel='stylesheet' href='https://unpkg.com/chevrotain@11.0.3/diagrams/diagrams.css'>
 
-<div id="diagrams" align="center"></div>
+<script src='https://unpkg.com/chevrotain@11.0.3/diagrams/vendor/railroad-diagrams.js'></script>
+<script src='https://unpkg.com/chevrotain@11.0.3/diagrams/src/diagrams_builder.js'></script>
+<script src='https://unpkg.com/chevrotain@11.0.3/diagrams/src/diagrams_behavior.js'></script>
+<script src='https://unpkg.com/chevrotain@11.0.3/diagrams/src/main.js'></script>
+
+<div id="diagrams" align="center"></div>    
 
 <script>
-  window.serializedGrammar = [
+    window.serializedGrammar = [
+  {
+    "type": "Rule",
+    "name": "file",
+    "orgText": "",
+    "definition": [
       {
-        'type': 'Rule',
-        'name': 'file',
-        'orgText': '',
-        'definition': [
+        "type": "Repetition",
+        "idx": 0,
+        "definition": [
           {
-            'type': 'Repetition',
-            'idx': 0,
-            'definition': [
-              {
-                'type': 'NonTerminal',
-                'name': 'statement',
-                'idx': 0,
-              },
-            ],
-          },
-        ],
-      },
+            "type": "NonTerminal",
+            "name": "statement",
+            "idx": 0
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "statement",
+    "orgText": "",
+    "definition": [
       {
-        'type': 'Rule',
-        'name': 'statement',
-        'orgText': '',
-        'definition': [
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
           {
-            'type': 'Alternation',
-            'idx': 0,
-            'definition': [
+            "type": "Alternative",
+            "definition": [
               {
-                'type': 'Alternative',
-                'definition': [
+                "type": "Option",
+                "idx": 0,
+                "definition": [
                   {
-                    'type': 'Option',
-                    'idx': 0,
-                    'definition': [
+                    "type": "Alternation",
+                    "idx": 1,
+                    "definition": [
                       {
-                        'type': 'Alternation',
-                        'idx': 1,
-                        'definition': [
+                        "type": "Alternative",
+                        "definition": [
                           {
-                            'type': 'Alternative',
-                            'definition': [
-                              {
-                                'type': 'Terminal',
-                                'name': 'LET',
-                                'label': 'LET',
-                                'idx': 0,
-                                'pattern': 'let',
-                              },
-                              {
-                                'type': 'NonTerminal',
-                                'name': 'declaration',
-                                'idx': 0,
-                              },
-                            ],
+                            "type": "Terminal",
+                            "name": "LET",
+                            "label": "LET",
+                            "idx": 0,
+                            "pattern": "let"
                           },
                           {
-                            'type': 'Alternative',
-                            'definition': [
-                              {
-                                'type': 'Terminal',
-                                'name': 'BREAK',
-                                'label': 'BREAK',
-                                'idx': 0,
-                                'pattern': 'break',
-                              },
-                            ],
+                            "type": "NonTerminal",
+                            "name": "declaration",
+                            "idx": 0
+                          }
+                        ]
+                      },
+                      {
+                        "type": "Alternative",
+                        "definition": [
+                          {
+                            "type": "Terminal",
+                            "name": "BREAK",
+                            "label": "BREAK",
+                            "idx": 0,
+                            "pattern": "break"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "Alternative",
+                        "definition": [
+                          {
+                            "type": "Terminal",
+                            "name": "CONTINUE",
+                            "label": "CONTINUE",
+                            "idx": 0,
+                            "pattern": "continue"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "Alternative",
+                        "definition": [
+                          {
+                            "type": "Terminal",
+                            "name": "RETURN",
+                            "label": "RETURN",
+                            "idx": 0,
+                            "pattern": "return"
                           },
                           {
-                            'type': 'Alternative',
-                            'definition': [
+                            "type": "Option",
+                            "idx": 2,
+                            "definition": [
                               {
-                                'type': 'Terminal',
-                                'name': 'CONTINUE',
-                                'label': 'CONTINUE',
-                                'idx': 0,
-                                'pattern': 'continue',
-                              },
-                            ],
-                          },
+                                "type": "NonTerminal",
+                                "name": "expression",
+                                "idx": 0
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "Alternative",
+                        "definition": [
                           {
-                            'type': 'Alternative',
-                            'definition': [
-                              {
-                                'type': 'Terminal',
-                                'name': 'RETURN',
-                                'label': 'RETURN',
-                                'idx': 0,
-                                'pattern': 'return',
-                              },
-                              {
-                                'type': 'Option',
-                                'idx': 2,
-                                'definition': [
-                                  {
-                                    'type': 'NonTerminal',
-                                    'name': 'expression',
-                                    'idx': 0,
-                                  },
-                                ],
-                              },
-                            ],
-                          },
+                            "type": "NonTerminal",
+                            "name": "expression",
+                            "idx": 2
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "Terminal",
+                "name": "SEMI",
+                "label": "SEMI",
+                "idx": 0,
+                "pattern": ";"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "IF",
+                "label": "IF",
+                "idx": 0,
+                "pattern": "if"
+              },
+              {
+                "type": "NonTerminal",
+                "name": "ifPredBody",
+                "idx": 1
+              },
+              {
+                "type": "Repetition",
+                "idx": 0,
+                "definition": [
+                  {
+                    "type": "Terminal",
+                    "name": "ELIF",
+                    "label": "ELIF",
+                    "idx": 0,
+                    "pattern": "elif"
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "ifPredBody",
+                    "idx": 2
+                  }
+                ]
+              },
+              {
+                "type": "Option",
+                "idx": 1,
+                "definition": [
+                  {
+                    "type": "Terminal",
+                    "name": "ELSE",
+                    "label": "ELSE",
+                    "idx": 0,
+                    "pattern": "else"
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "body",
+                    "idx": 3
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Option",
+                "idx": 3,
+                "definition": [
+                  {
+                    "type": "Terminal",
+                    "name": "DO",
+                    "label": "DO",
+                    "idx": 0,
+                    "pattern": "do"
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "body",
+                    "idx": 4
+                  }
+                ]
+              },
+              {
+                "type": "Terminal",
+                "name": "WHILE",
+                "label": "WHILE",
+                "idx": 0,
+                "pattern": "while"
+              },
+              {
+                "type": "NonTerminal",
+                "name": "expression",
+                "idx": 3
+              },
+              {
+                "type": "Alternation",
+                "idx": 2,
+                "definition": [
+                  {
+                    "type": "Alternative",
+                    "definition": [
+                      {
+                        "type": "Terminal",
+                        "name": "SEMI",
+                        "label": "SEMI",
+                        "idx": 2,
+                        "pattern": ";"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Alternative",
+                    "definition": [
+                      {
+                        "type": "NonTerminal",
+                        "name": "body",
+                        "idx": 5
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "Option",
+                "idx": 4,
+                "definition": [
+                  {
+                    "type": "Terminal",
+                    "name": "FINALLY",
+                    "label": "FINALLY",
+                    "idx": 0,
+                    "pattern": "finally"
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "body",
+                    "idx": 6
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "NonTerminal",
+                "name": "body",
+                "idx": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "ifPredBody",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Terminal",
+        "name": "LPAREN",
+        "label": "LPAREN",
+        "idx": 0,
+        "pattern": "("
+      },
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "LET",
+                "label": "LET",
+                "idx": 0,
+                "pattern": "let"
+              },
+              {
+                "type": "NonTerminal",
+                "name": "declaration",
+                "idx": 0
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "NonTerminal",
+                "name": "expression",
+                "idx": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Terminal",
+        "name": "RPAREN",
+        "label": "RPAREN",
+        "idx": 0,
+        "pattern": ")"
+      },
+      {
+        "type": "NonTerminal",
+        "name": "body",
+        "idx": 0
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "body",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Terminal",
+        "name": "LCURLY",
+        "label": "LCURLY",
+        "idx": 0,
+        "pattern": "{"
+      },
+      {
+        "type": "Repetition",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "NonTerminal",
+            "name": "statement",
+            "idx": 0
+          }
+        ]
+      },
+      {
+        "type": "Terminal",
+        "name": "RCURLY",
+        "label": "RCURLY",
+        "idx": 0,
+        "pattern": "}"
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "declaration",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Terminal",
+        "name": "ID",
+        "label": "ID",
+        "idx": 0,
+        "pattern": "[a-zA-Z_][a-zA-Z_\\d]*"
+      },
+      {
+        "type": "Option",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Terminal",
+            "name": "COLON",
+            "label": "COLON",
+            "idx": 0,
+            "pattern": ":"
+          },
+          {
+            "type": "NonTerminal",
+            "name": "type",
+            "idx": 0
+          }
+        ]
+      },
+      {
+        "type": "Option",
+        "idx": 1,
+        "definition": [
+          {
+            "type": "Terminal",
+            "name": "EQU",
+            "label": "EQU",
+            "idx": 0,
+            "pattern": "="
+          },
+          {
+            "type": "NonTerminal",
+            "name": "expression",
+            "idx": 0
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "expression",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "NonTerminal",
+        "name": "chainValue",
+        "idx": 0
+      },
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "PostFix",
+                "label": "PostFix",
+                "idx": 0,
+                "pattern": "NOT_APPLICABLE"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Option",
+                "idx": 0,
+                "definition": [
+                  {
+                    "type": "Alternation",
+                    "idx": 2,
+                    "definition": [
+                      {
+                        "type": "Alternative",
+                        "definition": [
                           {
-                            'type': 'Alternative',
-                            'definition': [
-                              {
-                                'type': 'NonTerminal',
-                                'name': 'expression',
-                                'idx': 2,
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  {
-                    'type': 'Terminal',
-                    'name': 'SEMI',
-                    'label': 'SEMI',
-                    'idx': 0,
-                    'pattern': ';',
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'IF',
-                    'label': 'IF',
-                    'idx': 0,
-                    'pattern': 'if',
-                  },
-                  {
-                    'type': 'NonTerminal',
-                    'name': 'ifPredBody',
-                    'idx': 1,
-                  },
-                  {
-                    'type': 'Repetition',
-                    'idx': 0,
-                    'definition': [
-                      {
-                        'type': 'Terminal',
-                        'name': 'ELIF',
-                        'label': 'ELIF',
-                        'idx': 0,
-                        'pattern': 'elif',
+                            "type": "Terminal",
+                            "name": "CmpAsgn",
+                            "label": "CmpAsgn",
+                            "idx": 0,
+                            "pattern": "NOT_APPLICABLE"
+                          }
+                        ]
                       },
                       {
-                        'type': 'NonTerminal',
-                        'name': 'ifPredBody',
-                        'idx': 2,
-                      },
-                    ],
-                  },
-                  {
-                    'type': 'Option',
-                    'idx': 1,
-                    'definition': [
-                      {
-                        'type': 'Terminal',
-                        'name': 'ELSE',
-                        'label': 'ELSE',
-                        'idx': 0,
-                        'pattern': 'else',
-                      },
-                      {
-                        'type': 'NonTerminal',
-                        'name': 'body',
-                        'idx': 3,
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Option',
-                    'idx': 3,
-                    'definition': [
-                      {
-                        'type': 'Terminal',
-                        'name': 'DO',
-                        'label': 'DO',
-                        'idx': 0,
-                        'pattern': 'do',
-                      },
-                      {
-                        'type': 'NonTerminal',
-                        'name': 'body',
-                        'idx': 4,
-                      },
-                    ],
-                  },
-                  {
-                    'type': 'Terminal',
-                    'name': 'WHILE',
-                    'label': 'WHILE',
-                    'idx': 0,
-                    'pattern': 'while',
-                  },
-                  {
-                    'type': 'NonTerminal',
-                    'name': 'expression',
-                    'idx': 3,
-                  },
-                  {
-                    'type': 'Alternation',
-                    'idx': 2,
-                    'definition': [
-                      {
-                        'type': 'Alternative',
-                        'definition': [
+                        "type": "Alternative",
+                        "definition": [
                           {
-                            'type': 'Terminal',
-                            'name': 'SEMI',
-                            'label': 'SEMI',
-                            'idx': 2,
-                            'pattern': ';',
-                          },
-                        ],
-                      },
-                      {
-                        'type': 'Alternative',
-                        'definition': [
-                          {
-                            'type': 'NonTerminal',
-                            'name': 'body',
-                            'idx': 5,
-                          },
-                        ],
-                      },
-                    ],
+                            "type": "Terminal",
+                            "name": "BinOp",
+                            "label": "BinOp",
+                            "idx": 0,
+                            "pattern": "NOT_APPLICABLE"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    'type': 'Option',
-                    'idx': 4,
-                    'definition': [
-                      {
-                        'type': 'Terminal',
-                        'name': 'FINALLY',
-                        'label': 'FINALLY',
-                        'idx': 0,
-                        'pattern': 'finally',
-                      },
-                      {
-                        'type': 'NonTerminal',
-                        'name': 'body',
-                        'idx': 6,
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'NonTerminal',
-                    'name': 'body',
-                    'idx': 0,
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+                    "type": "NonTerminal",
+                    "name": "expression",
+                    "idx": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "chainValue",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "NonTerminal",
+        "name": "value",
+        "idx": 0
       },
       {
-        'type': 'Rule',
-        'name': 'ifPredBody',
-        'orgText': '',
-        'definition': [
+        "type": "Repetition",
+        "idx": 0,
+        "definition": [
           {
-            'type': 'Terminal',
-            'name': 'LPAREN',
-            'label': 'LPAREN',
-            'idx': 0,
-            'pattern': '(',
+            "type": "Terminal",
+            "name": "LBRACK",
+            "label": "LBRACK",
+            "idx": 0,
+            "pattern": "["
           },
           {
-            'type': 'Alternation',
-            'idx': 0,
-            'definition': [
+            "type": "Option",
+            "idx": 0,
+            "definition": [
               {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'LET',
-                    'label': 'LET',
-                    'idx': 0,
-                    'pattern': 'let',
-                  },
-                  {
-                    'type': 'NonTerminal',
-                    'name': 'declaration',
-                    'idx': 0,
-                  },
-                ],
+                "type": "NonTerminal",
+                "name": "expression",
+                "idx": 0
+              }
+            ]
+          },
+          {
+            "type": "Option",
+            "idx": 1,
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "COLON",
+                "label": "COLON",
+                "idx": 0,
+                "pattern": ":"
               },
               {
-                'type': 'Alternative',
-                'definition': [
+                "type": "Option",
+                "idx": 2,
+                "definition": [
                   {
-                    'type': 'NonTerminal',
-                    'name': 'expression',
-                    'idx': 0,
-                  },
-                ],
+                    "type": "NonTerminal",
+                    "name": "expression",
+                    "idx": 1
+                  }
+                ]
               },
-            ],
+              {
+                "type": "Option",
+                "idx": 3,
+                "definition": [
+                  {
+                    "type": "Terminal",
+                    "name": "COLON",
+                    "label": "COLON",
+                    "idx": 1,
+                    "pattern": ":"
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "expression",
+                    "idx": 2
+                  }
+                ]
+              }
+            ]
           },
           {
-            'type': 'Terminal',
-            'name': 'RPAREN',
-            'label': 'RPAREN',
-            'idx': 0,
-            'pattern': ')',
-          },
-          {
-            'type': 'NonTerminal',
-            'name': 'body',
-            'idx': 0,
-          },
-        ],
-      },
+            "type": "Terminal",
+            "name": "RBRACK",
+            "label": "RBRACK",
+            "idx": 0,
+            "pattern": "]"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "value",
+    "orgText": "",
+    "definition": [
       {
-        'type': 'Rule',
-        'name': 'body',
-        'orgText': '',
-        'definition': [
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
           {
-            'type': 'Terminal',
-            'name': 'LCURLY',
-            'label': 'LCURLY',
-            'idx': 0,
-            'pattern': '{',
-          },
-          {
-            'type': 'Repetition',
-            'idx': 0,
-            'definition': [
+            "type": "Alternative",
+            "definition": [
               {
-                'type': 'NonTerminal',
-                'name': 'statement',
-                'idx': 0,
+                "type": "Terminal",
+                "name": "UnOp",
+                "label": "UnOp",
+                "idx": 0,
+                "pattern": "NOT_APPLICABLE"
               },
-            ],
+              {
+                "type": "NonTerminal",
+                "name": "chainValue",
+                "idx": 1
+              }
+            ]
           },
           {
-            'type': 'Terminal',
-            'name': 'RCURLY',
-            'label': 'RCURLY',
-            'idx': 0,
-            'pattern': '}',
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "NonTerminal",
+                "name": "constant",
+                "idx": 0
+              }
+            ]
           },
-        ],
-      },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "ID",
+                "label": "ID",
+                "idx": 0,
+                "pattern": "[a-zA-Z_][a-zA-Z_\\d]*"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "LPAREN",
+                "label": "LPAREN",
+                "idx": 0,
+                "pattern": "("
+              },
+              {
+                "type": "NonTerminal",
+                "name": "expression",
+                "idx": 0
+              },
+              {
+                "type": "Terminal",
+                "name": "RPAREN",
+                "label": "RPAREN",
+                "idx": 0,
+                "pattern": ")"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "constant",
+    "orgText": "",
+    "definition": [
       {
-        'type': 'Rule',
-        'name': 'declaration',
-        'orgText': '',
-        'definition': [
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
           {
-            'type': 'Terminal',
-            'name': 'ID',
-            'label': 'ID',
-            'idx': 0,
-            'pattern': '[a-zA-Z_][a-zA-Z_\\d]*',
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "STRING",
+                "label": "STRING",
+                "idx": 0,
+                "pattern": "(\"(\\\\\"|[^\"])*\")|('(\\\\'|[^'])*')"
+              }
+            ]
           },
           {
-            'type': 'Option',
-            'idx': 0,
-            'definition': [
+            "type": "Alternative",
+            "definition": [
               {
-                'type': 'Terminal',
-                'name': 'COLON',
-                'label': 'COLON',
-                'idx': 0,
-                'pattern': ':',
-              },
-              {
-                'type': 'NonTerminal',
-                'name': 'type',
-                'idx': 0,
-              },
-            ],
+                "type": "Terminal",
+                "name": "BOOL",
+                "label": "BOOL",
+                "idx": 0,
+                "pattern": "true|false"
+              }
+            ]
           },
           {
-            'type': 'Option',
-            'idx': 1,
-            'definition': [
+            "type": "Alternative",
+            "definition": [
               {
-                'type': 'Terminal',
-                'name': 'EQU',
-                'label': 'EQU',
-                'idx': 0,
-                'pattern': '=',
-              },
-              {
-                'type': 'NonTerminal',
-                'name': 'expression',
-                'idx': 0,
-              },
-            ],
+                "type": "Terminal",
+                "name": "BIN",
+                "label": "BIN",
+                "idx": 0,
+                "pattern": "(0x([0-9a-fA-F][0-9a-fA-F_]*[0-9a-fA-F]|[0-9a-fA-F]))|(0o([0-7][0-7_]*[0-7]|[0-7]))|(0b([01][01_]*[01]|[01]))"
+              }
+            ]
           },
-        ],
-      },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "CMPX",
+                "label": "CMPX",
+                "idx": 0,
+                "pattern": "(((\\+|-)?((0|[1-9]([\\d_]+\\d|\\d)?)\\.\\d+|inf)|NaN)(\\+|-))?((\\+|-)?((0|[1-9]([\\d_]+\\d|\\d)?)\\.\\d+|inf)|NaN)(i|j|I|J)"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "REAL",
+                "label": "REAL",
+                "idx": 0,
+                "pattern": "((\\+|-)?((0|[1-9]([\\d_]+\\d|\\d)?)\\.\\d+|inf)|NaN)"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "INT",
+                "label": "INT",
+                "idx": 0,
+                "pattern": "(\\+|-)?(0|[1-9]([\\d_]+\\d|\\d)?)"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "LBRACK",
+                "label": "LBRACK",
+                "idx": 0,
+                "pattern": "["
+              },
+              {
+                "type": "RepetitionWithSeparator",
+                "idx": 0,
+                "separator": {
+                  "type": "Terminal",
+                  "name": "SEP",
+                  "label": "SEP",
+                  "idx": 1
+                },
+                "definition": [
+                  {
+                    "type": "NonTerminal",
+                    "name": "expression",
+                    "idx": 0
+                  }
+                ]
+              },
+              {
+                "type": "Terminal",
+                "name": "RBRACK",
+                "label": "RBRACK",
+                "idx": 0,
+                "pattern": "]"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "type",
+    "orgText": "",
+    "definition": [
       {
-        'type': 'Rule',
-        'name': 'expression',
-        'orgText': '',
-        'definition': [
-          {
-            'type': 'NonTerminal',
-            'name': 'value',
-            'idx': 0,
-          },
-          {
-            'type': 'Alternation',
-            'idx': 0,
-            'definition': [
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'PostFix',
-                    'label': 'PostFix',
-                    'idx': 0,
-                    'pattern': 'NOT_APPLICABLE',
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Option',
-                    'idx': 0,
-                    'definition': [
-                      {
-                        'type': 'Alternation',
-                        'idx': 2,
-                        'definition': [
-                          {
-                            'type': 'Alternative',
-                            'definition': [
-                              {
-                                'type': 'Terminal',
-                                'name': 'CmpAsgn',
-                                'label': 'CmpAsgn',
-                                'idx': 0,
-                                'pattern': 'NOT_APPLICABLE',
-                              },
-                            ],
-                          },
-                          {
-                            'type': 'Alternative',
-                            'definition': [
-                              {
-                                'type': 'Terminal',
-                                'name': 'BinOp',
-                                'label': 'BinOp',
-                                'idx': 0,
-                                'pattern': 'NOT_APPLICABLE',
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      {
-                        'type': 'NonTerminal',
-                        'name': 'expression',
-                        'idx': 0,
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        'type': 'Rule',
-        'name': 'value',
-        'orgText': '',
-        'definition': [
-          {
-            'type': 'Alternation',
-            'idx': 0,
-            'definition': [
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'UnOp',
-                    'label': 'UnOp',
-                    'idx': 0,
-                    'pattern': 'NOT_APPLICABLE',
-                  },
-                  {
-                    'type': 'NonTerminal',
-                    'name': 'value',
-                    'idx': 1,
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'NonTerminal',
-                    'name': 'constant',
-                    'idx': 0,
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'ID',
-                    'label': 'ID',
-                    'idx': 0,
-                    'pattern': '[a-zA-Z_][a-zA-Z_\\d]*',
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'LPAREN',
-                    'label': 'LPAREN',
-                    'idx': 0,
-                    'pattern': '(',
-                  },
-                  {
-                    'type': 'NonTerminal',
-                    'name': 'expression',
-                    'idx': 0,
-                  },
-                  {
-                    'type': 'Terminal',
-                    'name': 'RPAREN',
-                    'label': 'RPAREN',
-                    'idx': 0,
-                    'pattern': ')',
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        'type': 'Rule',
-        'name': 'constant',
-        'orgText': '',
-        'definition': [
-          {
-            'type': 'Alternation',
-            'idx': 0,
-            'definition': [
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'STRING',
-                    'label': 'STRING',
-                    'idx': 0,
-                    'pattern': '("(\\\\"|[^"])*")|(\'(\\\\\'|[^\'])*\')',
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'BOOL',
-                    'label': 'BOOL',
-                    'idx': 0,
-                    'pattern': 'true|false',
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'BIN',
-                    'label': 'BIN',
-                    'idx': 0,
-                    'pattern':
-                      '(0x([0-9a-fA-F][0-9a-fA-F_]*[0-9a-fA-F]|[0-9a-fA-F]))|(0o([0-7][0-7_]*[0-7]|[0-7]))|(0b([01][01_]*[01]|[01]))',
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'INT',
-                    'label': 'INT',
-                    'idx': 0,
-                    'pattern': '(\\+|-)?(0|[1-9]([\\d_]+\\d|\\d)?)',
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'CMPX',
-                    'label': 'CMPX',
-                    'idx': 0,
-                    'pattern':
-                      '(((\\+|-)?((0|[1-9]([\\d_]+\\d|\\d)?)\\.\\d+|inf)|NaN)(\\+|-))?((\\+|-)?((0|[1-9]([\\d_]+\\d|\\d)?)\\.\\d+|inf)|NaN)(i|j|I|J)',
-                  },
-                ],
-              },
-              {
-                'type': 'Alternative',
-                'definition': [
-                  {
-                    'type': 'Terminal',
-                    'name': 'REAL',
-                    'label': 'REAL',
-                    'idx': 0,
-                    'pattern': '((\\+|-)?((0|[1-9]([\\d_]+\\d|\\d)?)\\.\\d+|inf)|NaN)',
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        'type': 'Rule',
-        'name': 'type',
-        'orgText': '',
-        'definition': [
-          {
-            'type': 'Terminal',
-            'name': 'BASIC_TYPE',
-            'label': 'BASIC_TYPE',
-            'idx': 0,
-            'pattern': 'bool|(i|u|b)(8|16|32|64)|(r|x)(32|64)|string',
-          },
-        ],
-      },
-    ];
+        "type": "Terminal",
+        "name": "BASIC_TYPE",
+        "label": "BASIC_TYPE",
+        "idx": 0,
+        "pattern": "bool|(i|u|b)(8|16|32|64)|(r|x)(32|64)|string"
+      }
+    ]
+  }
+];
 </script>
 
 <script>
-  var diagramsDiv = document.getElementById('diagrams');
+    var diagramsDiv = document.getElementById("diagrams");
     main.drawDiagramsFromSerializedGrammar(serializedGrammar, diagramsDiv);
 </script>

--- a/apps/parser/generated/syntax-diagrams.html
+++ b/apps/parser/generated/syntax-diagrams.html
@@ -779,9 +779,10 @@
                 "idx": 0,
                 "separator": {
                   "type": "Terminal",
-                  "name": "SEP",
-                  "label": "SEP",
-                  "idx": 1
+                  "name": "COMMA",
+                  "label": "COMMA",
+                  "idx": 1,
+                  "pattern": ","
                 },
                 "definition": [
                   {

--- a/apps/parser/generated/syntax-diagrams.html
+++ b/apps/parser/generated/syntax-diagrams.html
@@ -525,73 +525,85 @@
         "idx": 0,
         "definition": [
           {
+            "type": "NonTerminal",
+            "name": "indexOrSlice",
+            "idx": 0
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "indexOrSlice",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Terminal",
+        "name": "LBRACK",
+        "label": "LBRACK",
+        "idx": 0,
+        "pattern": "["
+      },
+      {
+        "type": "Option",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "NonTerminal",
+            "name": "expression",
+            "idx": 0
+          }
+        ]
+      },
+      {
+        "type": "Option",
+        "idx": 1,
+        "definition": [
+          {
             "type": "Terminal",
-            "name": "LBRACK",
-            "label": "LBRACK",
+            "name": "COLON",
+            "label": "COLON",
             "idx": 0,
-            "pattern": "["
+            "pattern": ":"
           },
           {
             "type": "Option",
-            "idx": 0,
+            "idx": 2,
             "definition": [
               {
                 "type": "NonTerminal",
                 "name": "expression",
-                "idx": 0
+                "idx": 1
               }
             ]
           },
           {
             "type": "Option",
-            "idx": 1,
+            "idx": 3,
             "definition": [
               {
                 "type": "Terminal",
                 "name": "COLON",
                 "label": "COLON",
-                "idx": 0,
+                "idx": 1,
                 "pattern": ":"
               },
               {
-                "type": "Option",
-                "idx": 2,
-                "definition": [
-                  {
-                    "type": "NonTerminal",
-                    "name": "expression",
-                    "idx": 1
-                  }
-                ]
-              },
-              {
-                "type": "Option",
-                "idx": 3,
-                "definition": [
-                  {
-                    "type": "Terminal",
-                    "name": "COLON",
-                    "label": "COLON",
-                    "idx": 1,
-                    "pattern": ":"
-                  },
-                  {
-                    "type": "NonTerminal",
-                    "name": "expression",
-                    "idx": 2
-                  }
-                ]
+                "type": "NonTerminal",
+                "name": "expression",
+                "idx": 2
               }
             ]
-          },
-          {
-            "type": "Terminal",
-            "name": "RBRACK",
-            "label": "RBRACK",
-            "idx": 0,
-            "pattern": "]"
           }
         ]
+      },
+      {
+        "type": "Terminal",
+        "name": "RBRACK",
+        "label": "RBRACK",
+        "idx": 0,
+        "pattern": "]"
       }
     ]
   },

--- a/apps/parser/main.ts
+++ b/apps/parser/main.ts
@@ -37,14 +37,15 @@ export async function main(): Promise<void> {
   const lexingResult = CalvinLexer.tokenize(inputFile);
   // "input" is a setter which will reset the parser's state.
   parser.input = lexingResult.tokens;
+
+  const output = parser.file();
+
   if (parser.errors.length > 0) {
     throw new AggregateError(
       parser.errors,
       'One or more errors occurred during the parsing phase!',
     );
   }
-
-  const output = parser.file();
 
   printer.visit(output);
 }

--- a/apps/parser/src/lexer.ts
+++ b/apps/parser/src/lexer.ts
@@ -214,6 +214,7 @@ export const LBRACK: TokenType = createToken({ name: 'LBRACK', pattern: '[' });
 export const RBRACK: TokenType = createToken({ name: 'RBRACK', pattern: ']' });
 export const SEMI: TokenType = createToken({ name: 'SEMI', pattern: ';' });
 export const COLON: TokenType = createToken({ name: 'COLON', pattern: ':' });
+export const COMMA: TokenType = createToken({ name: 'COMMA', pattern: ',' });
 /* Keywords */
 export const LET: TokenType = createToken({ name: 'LET', pattern: 'let', longer_alt: ID });
 // Selection
@@ -275,6 +276,7 @@ export const allTokens: TokenType[] = [
   RBRACK,
   SEMI,
   COLON,
+  COMMA,
   ERROR,
 ];
 

--- a/apps/parser/src/lexer.ts
+++ b/apps/parser/src/lexer.ts
@@ -210,6 +210,8 @@ export const LPAREN: TokenType = createToken({ name: 'LPAREN', pattern: '(' });
 export const RPAREN: TokenType = createToken({ name: 'RPAREN', pattern: ')' });
 export const LCURLY: TokenType = createToken({ name: 'LCURLY', pattern: '{' });
 export const RCURLY: TokenType = createToken({ name: 'RCURLY', pattern: '}' });
+export const LBRACK: TokenType = createToken({ name: 'LBRACK', pattern: '[' });
+export const RBRACK: TokenType = createToken({ name: 'RBRACK', pattern: ']' });
 export const SEMI: TokenType = createToken({ name: 'SEMI', pattern: ';' });
 export const COLON: TokenType = createToken({ name: 'COLON', pattern: ':' });
 /* Keywords */
@@ -269,6 +271,8 @@ export const allTokens: TokenType[] = [
   RPAREN,
   LCURLY,
   RCURLY,
+  LBRACK,
+  RBRACK,
   SEMI,
   COLON,
   ERROR,

--- a/apps/parser/src/parser.ts
+++ b/apps/parser/src/parser.ts
@@ -208,7 +208,7 @@ export class CalvinParser extends CstParser {
         ALT: () => {
           this.CONSUME(Tokens.LBRACK);
           this.MANY_SEP({
-            SEP: () => this.CONSUME(Tokens.COMMA),
+            SEP: Tokens.COMMA,
             DEF: () => this.SUBRULE(this.expression),
           });
           this.CONSUME(Tokens.RBRACK);

--- a/apps/parser/src/parser.ts
+++ b/apps/parser/src/parser.ts
@@ -198,7 +198,19 @@ export class CalvinParser extends CstParser {
   });
 
   private constant = this.RULE('constant', () =>
-    this.OR(Tokens.literals.map((t) => ({ ALT: () => this.CONSUME(t) }))),
+    this.OR([
+      ...Tokens.literals.map((t) => ({ ALT: () => this.CONSUME(t) })),
+      {
+        ALT: () => {
+          this.CONSUME(Tokens.LBRACK);
+          this.MANY_SEP({
+            SEP: () => this.CONSUME(Tokens.COMMA),
+            DEF: () => this.SUBRULE(this.expression),
+          });
+          this.CONSUME(Tokens.RBRACK);
+        },
+      },
+    ]),
   );
 
   private type = this.RULE('type', () => this.CONSUME(Tokens.BASIC_TYPE));

--- a/apps/parser/src/parser.ts
+++ b/apps/parser/src/parser.ts
@@ -129,7 +129,7 @@ export class CalvinParser extends CstParser {
   });
 
   private expression = this.RULE('expression', () => {
-    this.SUBRULE(this.value);
+    this.SUBRULE(this.chainValue);
     this.OR([
       {
         ALT: () => this.CONSUME(Tokens.PostFix),
@@ -153,12 +153,32 @@ export class CalvinParser extends CstParser {
     ]);
   });
 
+  private chainValue = this.RULE('chainValue', () => {
+    this.SUBRULE(this.value);
+    this.MANY(() => {
+      this.CONSUME(Tokens.LBRACK);
+      // This allows for expressions of the form arr[] to be syntactically valid
+      // I don't like it, but I guess this can be handled on the semantic level???
+      // This was the best way I could fix the common lookahead prefix error
+      this.OPTION(() => this.SUBRULE(this.expression));
+      this.OPTION1(() => {
+        this.CONSUME(Tokens.COLON);
+        this.OPTION2(() => this.SUBRULE1(this.expression));
+        this.OPTION3(() => {
+          this.CONSUME1(Tokens.COLON);
+          this.SUBRULE2(this.expression);
+        });
+      });
+      this.CONSUME(Tokens.RBRACK);
+    });
+  });
+
   private value = this.RULE('value', () => {
     this.OR([
       {
         ALT: () => {
           this.CONSUME(Tokens.UnOp);
-          this.SUBRULE1(this.value);
+          this.SUBRULE1(this.chainValue);
         },
       },
       {

--- a/apps/parser/src/parser.ts
+++ b/apps/parser/src/parser.ts
@@ -156,21 +156,25 @@ export class CalvinParser extends CstParser {
   private chainValue = this.RULE('chainValue', () => {
     this.SUBRULE(this.value);
     this.MANY(() => {
-      this.CONSUME(Tokens.LBRACK);
-      // This allows for expressions of the form arr[] to be syntactically valid
-      // I don't like it, but I guess this can be handled on the semantic level???
-      // This was the best way I could fix the common lookahead prefix error
-      this.OPTION(() => this.SUBRULE(this.expression));
-      this.OPTION1(() => {
-        this.CONSUME(Tokens.COLON);
-        this.OPTION2(() => this.SUBRULE1(this.expression));
-        this.OPTION3(() => {
-          this.CONSUME1(Tokens.COLON);
-          this.SUBRULE2(this.expression);
-        });
-      });
-      this.CONSUME(Tokens.RBRACK);
+      this.SUBRULE(this.indexOrSlice);
     });
+  });
+
+  private indexOrSlice = this.RULE('indexOrSlice', () => {
+    this.CONSUME(Tokens.LBRACK);
+    // This allows for expressions of the form arr[] to be syntactically valid
+    // I don't like it, but I guess this can be handled on the semantic level???
+    // This was the best way I could fix the common lookahead prefix error
+    this.OPTION(() => this.SUBRULE(this.expression));
+    this.OPTION1(() => {
+      this.CONSUME(Tokens.COLON);
+      this.OPTION2(() => this.SUBRULE1(this.expression));
+      this.OPTION3(() => {
+        this.CONSUME1(Tokens.COLON);
+        this.SUBRULE2(this.expression);
+      });
+    });
+    this.CONSUME(Tokens.RBRACK);
   });
 
   private value = this.RULE('value', () => {

--- a/apps/parser/src/parser.ts
+++ b/apps/parser/src/parser.ts
@@ -217,7 +217,18 @@ export class CalvinParser extends CstParser {
     ]),
   );
 
-  private type = this.RULE('type', () => this.CONSUME(Tokens.BASIC_TYPE));
+  private type = this.RULE('type', () => {
+    this.CONSUME(Tokens.BASIC_TYPE);
+    this.MANY(() => {
+      this.SUBRULE(this.arrayType);
+    });
+  });
+
+  private arrayType = this.RULE('arrayType', () => {
+    this.CONSUME(Tokens.LBRACK);
+    this.OPTION(() => this.CONSUME(Tokens.INT));
+    this.CONSUME(Tokens.RBRACK);
+  });
 }
 
 export const parser: CalvinParser = new CalvinParser();

--- a/apps/parser/src/visitors/printer.ts
+++ b/apps/parser/src/visitors/printer.ts
@@ -231,6 +231,12 @@ export class CalvinPrinter extends BaseCstVisitor implements ICstNodeVisitor<num
       case 'expression':
         this.expression(node.children as ExpressionCstChildren, indent);
         break;
+      case 'chainValue':
+        this.chainValue(node.children as ChainValueCstChildren, indent);
+        break;
+      case 'indexOrSlice':
+        this.indexOrSlice(node.children as IndexOrSliceCstChildren, indent);
+        break;
       case 'value':
         this.value(node.children as ValueCstChildren, indent);
         break;

--- a/apps/parser/src/visitors/printer.ts
+++ b/apps/parser/src/visitors/printer.ts
@@ -143,6 +143,11 @@ export class CalvinPrinter extends BaseCstVisitor implements ICstNodeVisitor<num
 
   chainValue(cval: ChainValueCstChildren, indent: number) {
     this.value(cval.value[0].children, indent);
+    if (cval.indexOrSlice) {
+      cval.indexOrSlice.forEach((ios) => {
+        this.indexOrSlice(ios.children, indent);
+      });
+    }
   }
 
   indexOrSlice(ios: IndexOrSliceCstChildren, indent: number) {

--- a/apps/parser/src/visitors/printer.ts
+++ b/apps/parser/src/visitors/printer.ts
@@ -1,5 +1,6 @@
 import type { CstNode, IToken } from 'chevrotain';
 import type {
+  ArrayTypeCstChildren,
   BodyCstChildren,
   ChainValueCstChildren,
   ConstantCstChildren,
@@ -209,6 +210,15 @@ export class CalvinPrinter extends BaseCstVisitor implements ICstNodeVisitor<num
 
   type(t: TypeCstChildren, indent: number) {
     tree(`: ${t.BASIC_TYPE[0].image}`, indent);
+    if (t.arrayType) {
+      t.arrayType.forEach((at) => {
+        this.arrayType(at.children, indent + 2);
+      });
+    }
+  }
+
+  arrayType(a: ArrayTypeCstChildren, indent: number) {
+    tree(`[${a.INT?.at(0)?.image ?? ''}]`, indent);
   }
 
   override visit(node: CstNode, indent: number = 0) {
@@ -245,6 +255,9 @@ export class CalvinPrinter extends BaseCstVisitor implements ICstNodeVisitor<num
         break;
       case 'type':
         this.type(node.children as TypeCstChildren, indent);
+        break;
+      case 'arrayType':
+        this.arrayType(node.children as ArrayTypeCstChildren, indent);
         break;
     }
   }

--- a/apps/parser/test/end-to-end/fixtures/arrays.txt
+++ b/apps/parser/test/end-to-end/fixtures/arrays.txt
@@ -4,3 +4,5 @@ let sliced = arr[1:2];
 let indexed = arr[0];
 let indexOfSliced = sliced[0];
 let check = indexed == indexOfSliced;
+let multi = [[1, 2], [3, 4]];
+let badMulti = [[1, 2], 3]; // should have semantic error

--- a/apps/parser/test/end-to-end/fixtures/arrays.txt
+++ b/apps/parser/test/end-to-end/fixtures/arrays.txt
@@ -6,3 +6,4 @@ let indexOfSliced = sliced[0];
 let check = indexed == indexOfSliced;
 let multi: i32[2][] = [[1, 2], [3, 4]];
 let badMulti = [[1, 2], 3]; // should have semantic error
+let badIndex = arr[1][1];

--- a/apps/parser/test/end-to-end/fixtures/arrays.txt
+++ b/apps/parser/test/end-to-end/fixtures/arrays.txt
@@ -1,7 +1,7 @@
 let arr = [1, 2];
 let empty: i32[] = []; // otherwise type is unknown[]
 let sliced = arr[1:2];
-let indexed = arr[0];
+let indexed = arr[0 + 1 - 1];
 let indexOfSliced = sliced[0];
 let check = indexed == indexOfSliced;
 let multi: i32[2][] = [[1, 2], [3, 4]];

--- a/apps/parser/test/end-to-end/fixtures/arrays.txt
+++ b/apps/parser/test/end-to-end/fixtures/arrays.txt
@@ -1,0 +1,6 @@
+let arr = [1, 2];
+let empty = [];
+let sliced = arr[1:2];
+let indexed = arr[0];
+let indexOfSliced = sliced[0];
+let check = indexed == indexOfSliced;

--- a/apps/parser/test/end-to-end/fixtures/arrays.txt
+++ b/apps/parser/test/end-to-end/fixtures/arrays.txt
@@ -1,8 +1,8 @@
 let arr = [1, 2];
-let empty = [];
+let empty: i32[] = []; // otherwise type is unknown[]
 let sliced = arr[1:2];
 let indexed = arr[0];
 let indexOfSliced = sliced[0];
 let check = indexed == indexOfSliced;
-let multi = [[1, 2], [3, 4]];
+let multi: i32[2][] = [[1, 2], [3, 4]];
 let badMulti = [[1, 2], 3]; // should have semantic error

--- a/apps/parser/yacc-reference/lex.l
+++ b/apps/parser/yacc-reference/lex.l
@@ -165,15 +165,15 @@ using   return yy::parser::make_USING   (loc);
 "}"     return yy::parser::make_RBRACE  (loc); // DONE
 "("     return yy::parser::make_LPAREN  (loc); // DONE
 ")"     return yy::parser::make_RPAREN  (loc); // DONE
-"["     return yy::parser::make_LBRACK  (loc);
-"]"     return yy::parser::make_RBRACK  (loc);
+"["     return yy::parser::make_LBRACK  (loc); // DONE
+"]"     return yy::parser::make_RBRACK  (loc); // DONE
 ";"     return yy::parser::make_SEMI    (loc); // DONE
 "_"     return yy::parser::make_USCORE  (loc);
 "?"     return yy::parser::make_QUE     (loc);
 "!"     return yy::parser::make_BANG    (loc);
 ":"     return yy::parser::make_COLON   (loc); // DONE
 "??"    return yy::parser::make_N_COAL  (loc); // DONE
-","     return yy::parser::make_COMMA   (loc);
+","     return yy::parser::make_COMMA   (loc); // DONE
 "."     return yy::parser::make_DOT     (loc);
 .       { throw yy::parser::syntax_error(loc, "invalid character: " + std::string(yytext));}
 <<EOF>> return yy::parser::make_YYEOF (loc);

--- a/apps/parser/yacc-reference/parser.y
+++ b/apps/parser/yacc-reference/parser.y
@@ -369,7 +369,7 @@ compound_assign: // DONE
     | value RS_EQU expression 
     | value AS_EQU expression
     | value NC_EQU expression;
-value: // 2/15
+value: // 5/15
     constant // DONE
     | ID // DONE
     | GLOBAL ID
@@ -380,10 +380,10 @@ value: // 2/15
     | function_call
     | value optional_chain DOT ID
     | value optional_chain DOT function_call
-    | value optional_chain LBRACK expression RBRACK
-    | value optional_chain LBRACK slice RBRACK
+    | value optional_chain LBRACK expression RBRACK // DONE
+    | value optional_chain LBRACK slice RBRACK // DONE
     | LBRACE list_expression RBRACE
-    | LPAREN expression RPAREN
+    | LPAREN expression RPAREN // DONE
     | type_signature LPAREN expression RPAREN;
 constant: // DONE
     BOOL { debug::log(drv.trace_parsing) << std::endl << "Parser push boolean: " << $1 << std::endl << std::endl; }
@@ -398,7 +398,7 @@ optional_chain:
     QUE
     | BANG
     |;
-slice:
+slice: // DONE
     optional_expression COLON optional_expression
     | optional_expression COLON optional_expression COLON expression;
 


### PR DESCRIPTION
Closes #26.
Part 1/4 of #35.

```
let arr = [1, 2, 3]; // array literal
let x = arr[0]; // array index
let slice = arr[:]; // slice of the whole array
let fullSlice = arr[1:2:-1]; // full array slice
let y = arr[]; // index with no expression. Not sure on this. artifact of parser rules
let arr2: i32[] = [1, 2, 3]; // explicit type
```

Potential issue:
I ran into a `common lookahead prefix` error when trying to require an expression in between the brackets for array indexing, but make it optional for array slices (i.e. `arr[:]`).
The best solution I could find was to just allow for empty brackets for array indexing. I'm not a big fan of it. I wish I could make it a syntax error, but so far I think the best I can do is a semantic error.